### PR TITLE
Add custom color support via a Game Boy Color custom palette.

### DIFF
--- a/appData/src/gb/Makefile
+++ b/appData/src/gb/Makefile
@@ -5,7 +5,7 @@ ROM_BUILD_DIR = build/rom
 OBJ_DIR = obj
 SOURCE_DIR = src
 
-CFLAGS = -DUSE_SFR_FOR_REG -Wl-yo64 -Wl-ya4
+CFLAGS = -DUSE_SFR_FOR_REG -Wl-yo64 -Wl-ya4 -Wl-yp0x143=0x80
 
 SOURCES := $(shell find -L $(SOURCE_DIR) -name '*.c')
 SOURCES_ASM := $(shell find -L $(SOURCE_DIR) -name '*.s')

--- a/appData/src/gb/include/game.h
+++ b/appData/src/gb/include/game.h
@@ -1,7 +1,14 @@
 #ifndef GAME_H
 #define GAME_H
 
+#define CUSTOM_COLORS
+
 #include <gb/gb.h>
+
+#ifdef CUSTOM_COLORS
+	#include <gb/cgb.h>
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -12,6 +19,21 @@
 #define SCREEN_HEIGHT 144
 #define SCREEN_WIDTH_HALF 80
 #define SCREEN_HEIGHT_HALF 72
+
+#ifdef CUSTOM_COLORS
+	#define CUSTOM_PALETTE_0_R 28
+	#define CUSTOM_PALETTE_0_G 31
+	#define CUSTOM_PALETTE_0_B 26
+	#define CUSTOM_PALETTE_1_R 17
+	#define CUSTOM_PALETTE_1_G 24
+	#define CUSTOM_PALETTE_1_B 14
+	#define CUSTOM_PALETTE_2_R 6
+	#define CUSTOM_PALETTE_2_G 13
+	#define CUSTOM_PALETTE_2_B 10
+	#define CUSTOM_PALETTE_3_R 1
+	#define CUSTOM_PALETTE_3_G 3
+	#define CUSTOM_PALETTE_3_B 4
+#ifdef CUSTOM_COLORS
 
 extern STAGE_TYPE stage_type;
 extern STAGE_TYPE stage_next_type;

--- a/appData/src/gb/src/game.c
+++ b/appData/src/gb/src/game.c
@@ -24,6 +24,12 @@ UBYTE script_actor;
 
 UBYTE scene_stack_ptr = 0;
 SCENE_STATE scene_stack[MAX_SCENE_STATES] = {{0}};
+#ifdef CUSTOM_COLORS
+UINT16 custom_palette[] = { RGB(CUSTOM_PALETTE_0_R, CUSTOM_PALETTE_0_G, CUSTOM_PALETTE_0_B), 
+                            RGB(CUSTOM_PALETTE_1_R, CUSTOM_PALETTE_1_G, CUSTOM_PALETTE_1_B), 
+                            RGB(CUSTOM_PALETTE_2_R, CUSTOM_PALETTE_2_G, CUSTOM_PALETTE_2_B), 
+                            RGB(CUSTOM_PALETTE_3_R, CUSTOM_PALETTE_3_G, CUSTOM_PALETTE_3_B)};
+#endif
 
 void game_loop();
 
@@ -35,8 +41,21 @@ int main()
   STAT_REG = 0x45;
 
   // Set palettes
+  #ifdef CUSTOM_COLORS
+  if (_cpu == CGB_TYPE)
+  {
+    set_bkg_palette(0, 1, custom_palette);
+    set_sprite_palette(0, 1, custom_palette);
+  }
+  else
+  {
+    BGP_REG = 0xE4U;
+    OBP0_REG = 0xD2U;
+  }
+  #else
   BGP_REG = 0xE4U;
   OBP0_REG = 0xD2U;
+  #endif
 
   // Position Window Layer
   WY_REG = MAXWNDPOSY - 7;

--- a/src/lib/compiler/buildMakeBat.js
+++ b/src/lib/compiler/buildMakeBat.js
@@ -9,6 +9,7 @@ export default async (buildRoot, { CART_TYPE }) => {
 
   const CC = `..\\_gbs\\gbdk\\bin\\lcc -Wa-l -Wl-m -Wl-j -Wl-yt${CART_TYPE} -Iinclude`;
   const CFLAGS = `-DUSE_SFR_FOR_REG -Wl-yo64 -Wl-ya4`;
+  const CGBFLAGS = `-Wl-yp0x143=0x80`;
 
   const srcRoot = `${buildRoot}/src`;
   const dataRoot = `${buildRoot}/src/data`;
@@ -51,7 +52,7 @@ export default async (buildRoot, { CART_TYPE }) => {
     objFiles.push(objFile);
   }
 
-  cmds.push(`${CC} ${CFLAGS} -o build/rom/game.gb ${objFiles.join(" ")}`);
+  cmds.push(`${CC} ${CFLAGS} ${CGBFLAGS} -o build/rom/game.gb ${objFiles.join(" ")}`);
 
   return cmds.join("\n");
 };


### PR DESCRIPTION
Add custom color support via a Game Boy Color custom palette. Set the colors in game.h using range 0-31, and you can disable all custom color code by removing the #define at the top of game.h.

* **What is the new behavior (if this is a feature change)?**
Bring fydo's changes in to experiment with a javascript execution.
